### PR TITLE
450*300の領域を作成し、表示する処理の作成

### DIFF
--- a/Janken_B20071.pde
+++ b/Janken_B20071.pde
@@ -1,0 +1,6 @@
+void setup(){
+  surface.setSize(450,300);
+}
+
+void draw(){
+}


### PR DESCRIPTION
surface.setSizeを利用して、幅450、縦300の領域を実装した。
グーチョキパーの画像追加
セレクトエリア、コメントエリア、結果表示エリアの作成
じゃんけんアイコンクリックによるじゃんけんおよびその結果表示機能の実装